### PR TITLE
A few fixes to work with ProcessWire 3.x

### DIFF
--- a/Calendar/Calendar.module
+++ b/Calendar/Calendar.module
@@ -82,10 +82,10 @@ class Calendar extends WireData implements Module {
             $event_end_timestamp = (int)$e->getUnformatted(self::EVENT_END_FIELD);
 
             // start/end DateTime objects
-            $start_datetime = new DateTime();
+            $start_datetime = new \DateTime();
             $start_datetime->setTimestamp($event_start_timestamp);
 
-            $end_datetime = new DateTime();
+            $end_datetime = new \DateTime();
             $end_datetime->setTimestamp($event_end_timestamp);
 
             // generate recurrences by the RRULE

--- a/ProcessCalendarAdmin/ProcessCalendarAdmin.css
+++ b/ProcessCalendarAdmin/ProcessCalendarAdmin.css
@@ -26,7 +26,7 @@
 }
 
 .CalendarAdmin-loading {
-    background: #ffffff 10px 10px no-repeat url('images/ajax-loader.gif');
+    background: #ffffff 10px 10px no-repeat url("images/ajax-loader.gif");
     margin-left: 42px;
     line-height: 52px;
 }
@@ -60,6 +60,11 @@
 #CalendarAdmin-edit-event-dialog {
     display: none;
     padding: 15px;
+    text-align: center;
+}
+
+.ui-dialog-buttonpane.ui-widget-content .ui-dialog-buttonset {
+    text-align: center;
 }
 
 /* notifications */
@@ -71,6 +76,6 @@
 #CalendarAdmin-notification.success {
     background: #ddffdd;
 }
-#CalendarAdmin-notification.error{
+#CalendarAdmin-notification.error {
     background: #ffdddd;
 }

--- a/ProcessCalendarAdmin/ProcessCalendarAdmin.module
+++ b/ProcessCalendarAdmin/ProcessCalendarAdmin.module
@@ -121,9 +121,9 @@ class ProcessCalendarAdmin extends Process {
         <label for="title">Title</label>
         <input type="text" name="title" id="ca-ned-title" />
         <label for="starttime">Start</label>
-        <input type="text" name="starttime" id="ca-ned-starttime" placeholder="HH:MM" />
+        <input type="time" name="starttime" id="ca-ned-starttime" />
         <label for="endtime">End</label>
-        <input type="text" name="endtime" id="ca-ned-endtime" placeholder="HH:MM" />
+        <input type="time" name="endtime" id="ca-ned-endtime"/>
     </fieldset>
 </div>
 
@@ -159,8 +159,8 @@ HTML;
             $end_input = $input->get('end');
 
             // start / end dates
-            $start = new DateTime($start_input);
-            $end = new DateTime($end_input);
+            $start = new \DateTime($start_input);
+            $end = new \DateTime($end_input);
 
             // generate a list of json events for fullcalendar
             return $this->outputJsonEvents($start, $end);

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ array(start, end, page)
 // get module
 $calendar = wire('modules')->getModule('Calendar');
 // get upcoming events - 6 months ahead
-$start = new DateTime();
-$until = new DateTime();
-$until->add(new DateInterval('P6M'));
+$start = new \DateTime();
+$until = new \DateTime();
+$until->add(new \DateInterval('P6M'));
 $events = $calendar->expandEvents($start, $until);
 // render event
 echo '<table>';


### PR DESCRIPTION
The module works perfectly until it had to parse the events... It turned out that the DateTime() method is creating issues with ProcessWire 3.x. versions and I replaced it with \DateTime(). 

Hopefully now others can just install it and start using it.